### PR TITLE
Using a different OS user to run the logger and handling sigterm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,43 @@
-FROM python:3.7-slim-buster
+FROM python:3.7-slim-buster as build-env
 ENV PYTHONUNBUFFERED 1
-WORKDIR /code
-COPY ./requirements/base.txt /code/
-RUN pip install -r base.txt
-COPY celerylogger/celery_logger.py /code/
-CMD python celery_logger.py
+
+WORKDIR /usr/src/app
+
+# Installing `gosu` (https://github.com/tianon/gosu)
+RUN set -eux; \
+    apt-get update && \
+    apt-get install -yq wget gpg && \
+    wget https://github.com/tianon/gosu/releases/download/1.13/gosu-amd64 -O gosu && \
+    wget https://github.com/tianon/gosu/releases/download/1.13/gosu-amd64.asc -O gosu.asc && \
+    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && \
+    gpg --batch --verify gosu.asc gosu && \
+    chmod +x gosu
+
+# Copying package files...
+COPY ./requirements/ /usr/src/app/requirements/
+COPY ./setup.py /usr/src/app/
+COPY ./README.md /usr/src/app/
+COPY celerylogger/ /usr/src/app/celerylogger/
+
+# Installing python requirements
+RUN pip install .
+
+####################################
+
+FROM gcr.io/distroless/python3
+
+COPY --from=build-env /usr/src/app /usr/src/app
+COPY --from=build-env /usr/local/lib/python3.7/site-packages /usr/local/lib/python3.7/site-packages
+COPY --from=build-env /usr/src/app/gosu /usr/bin/
+
+WORKDIR /usr/src/app
+
+# App variables
+ENV PYTHONPATH=/usr/local/lib/python3.7/site-packages
+ENV CELERY_LOGGER_BROKER=""
+ENV CELERY_LOGGER_LOG_FILE=""
+
+# Running the logger with a non-root user
+# Note we don't need to create a human-readable user name, simply using the uid works.
+# References: https://github.com/GoogleContainerTools/distroless/issues/306
+ENTRYPOINT ["gosu", "888:888", "python", "celerylogger/celery_logger.py"]

--- a/celerylogger/celery_logger.py
+++ b/celerylogger/celery_logger.py
@@ -3,10 +3,16 @@
 import argparse
 import logging
 import os
+import signal
+import sys
 from functools import lru_cache
 
 from celery import Celery
 
+def setup_exit_signals():
+    exit_gracefully =lambda *args: sys.exit(0)
+    signal.signal(signal.SIGINT, exit_gracefully)
+    signal.signal(signal.SIGTERM, exit_gracefully)
 
 @lru_cache(maxsize=None)
 def get_logger(event_type):
@@ -80,6 +86,7 @@ def parse_args():
 
 
 def main():
+    setup_exit_signals()
     args = parse_args()
     if not args.celery_broker:
         raise ValueError("Argument --celery-broker is required")


### PR DESCRIPTION
## Context

- Closes #17
- Closes #18 


Since [Processes In Containers Should Not Run As Root](https://medium.com/@mccode/processes-in-containers-should-not-run-as-root-2feae3f0df3b), I adjusted the Dockerfile to ensure the celery-logger process will run with its own user.

## How to test
You can run the sample project (which uses the same dockerfile) to ensure everything works as expected.

Instructions at: https://github.com/CraveFood/celery-logger#getting-started

---

Sigterm tests:

![image](https://user-images.githubusercontent.com/9268203/129210733-ab422408-0388-4736-8f48-51eebe5c09f6.png)
