### PR TITLE
Decoupling log filters

### DIFF
--- a/sample-project/docker-compose.yaml
+++ b/sample-project/docker-compose.yaml
@@ -29,6 +29,8 @@ services:
             - CELERY_LOGGER_BROKER=redis://redis:6379/0
         links:
             - redis
+        volumes:
+            - ..:/usr/src/app
 
 volumes:
     redis-data:


### PR DESCRIPTION
The Python [logging library](https://docs.python.org/3/library/logging.html) provides a complete solution to deal with a vast logging scenarios.

The [Logging Cookbook](https://docs.python.org/3/howto/logging-cookbook.html) includes several useful recipes to deal with spcecial cases, such as `celery_logger` itself

This pull request decouples some tasks that usually the developer implements "by hand" such as:

- Delegates formatting to `logging.Formatter`
- Delegates filtering to custom filter `EventFilter`

### Minor fixes

- Maps docker volume to help with Debugging
- Changes de default path of `file` handler to`/tmp/celery_logger.log`